### PR TITLE
Update Rbind in Import_fromdirectory.R

### DIFF
--- a/CODE/MineDevelopment/Import_fromdirectory.R
+++ b/CODE/MineDevelopment/Import_fromdirectory.R
@@ -29,7 +29,7 @@ system.time(
     }  else { #If does
       temp_Data <- read_fwf(file, fwf_widths(ColWidths))
       
-      Data_Raw <- rbind(Data_Raw, temp_Data)
+      Data_Raw <- rbindlist(list(Data_Raw, temp_Data))
       
       count <- count + 1
       rm(temp_Data)


### PR DESCRIPTION
RBindList is much faster compare to RBind however it errors on function WideToLong in R_CleanData source .

Error:
`Error in data.frame(dat[1:4], V5 = rep(1:31, each = nrow(dat))) : arguments imply differing number of rows: 4, 4390871 `

